### PR TITLE
Fix Python3 print syntax and merge leftovers

### DIFF
--- a/MVP/python/DewpointChart.py
+++ b/MVP/python/DewpointChart.py
@@ -54,7 +54,7 @@ def buildChart(data, test=False):
     # Pivot the data by timestamp-bin with name groupings for columns
     df=df.pivot(index='timestamp', columns='name', values='value')
     if test:
-        print df
+        print(df)
 #    print df
 
 # Fill missing data with dummy value
@@ -84,7 +84,7 @@ def buildChart(data, test=False):
 # Clear index so all are columns
     d3=d1.reset_index()
     if test:
-        print d3
+        print(d3)
 
 #build chart
     line_chart = pygal.Line(range=(0, 40))
@@ -101,21 +101,21 @@ def getDewPointChart(test=False):
     data=getResults()
     r_cnt = len(data)
     if r_cnt>0:
-        print "Records: ", r_cnt
+        print("Records: ", r_cnt)
         data=cleanData(data, test)
         buildChart(data, test)
     else:
-        print "No Data"
+        print("No Data")
 
 def test():
     data=getResults()
     r_cnt = len(data)
     if r_cnt>0:
-        print "Records: ", r_cnt
+        print("Records: ", r_cnt)
         data=cleanData(data, test)
         buildChart(data, test)
     else:
-        print "No Data"
+        print("No Data")
 
 if __name__=="__main__":
     getDewPointChart()

--- a/MVP/python/Environment.py
+++ b/MVP/python/Environment.py
@@ -33,7 +33,7 @@ def setLights(on='06:30:00', off='22:00:00'):
 def prettyPrint(txt):
     '''Dump json in nice format'''
     #print type(txt)
-    print json.dumps(txt, indent=4, sort_keys=True)
+    print(json.dumps(txt, indent=4, sort_keys=True))
 
 def saveDict(name, file_name, dict):
     #print(values)

--- a/MVP/python/Fan.py
+++ b/MVP/python/Fan.py
@@ -99,34 +99,34 @@ def test():
                None
     """
     fan = Fan()
-    print "Test"
-    print "State: ", fan.relay.get_state(fan.fan_relay)
-    print "Turn Fan On"
+    print("Test")
+    print("State: ", fan.relay.get_state(fan.fan_relay))
+    print("Turn Fan On")
     fan.set_fan_on()
-    print "State: ", fan.relay.get_state(fan.fan_relay)
+    print("State: ", fan.relay.get_state(fan.fan_relay))
     time.sleep(2)
 
-    print "Turn Fan Off"
+    print("Turn Fan Off")
     fan.set_fan_off()
-    print "State: ", fan.relay.get_state(fan.fan_relay)
+    print("State: ", fan.relay.get_state(fan.fan_relay))
     time.sleep(2)
 
-    print "Adj 45"
+    print("Adj 45")
     fan.adjust(45, True)
-    print "State: ", fan.relay.get_state(fan.fan_relay)
+    print("State: ", fan.relay.get_state(fan.fan_relay))
 
-    print "Adj 45"
+    print("Adj 45")
     fan.adjust(45, True)
-    print "State: ", fan.relay.get_state(fan.fan_relay)
+    print("State: ", fan.relay.get_state(fan.fan_relay))
 
-    print "Adj 10"
+    print("Adj 10")
     fan.adjust(10, True)
-    print "State: ", fan.relay.get_state(fan.fan_relay)
+    print("State: ", fan.relay.get_state(fan.fan_relay))
 
-    print "Adj 45"
+    print("Adj 45")
     fan.adjust(45, True)
-    print "State: ", fan.relay.get_state(fan.fan_relay)
-    print "Done"
+    print("State: ", fan.relay.get_state(fan.fan_relay))
+    print("Done")
 
 if __name__ == "__main__":
     test()

--- a/MVP/python/HumidityChart.py
+++ b/MVP/python/HumidityChart.py
@@ -7,12 +7,9 @@ from couchdb import Server
 import json
 from datetime import datetime
 from MVP_Util import UTCStrToLDT
-<<<<<<< Updated upstream
-=======
 from LogUtil import get_logger
 
 logger = get_logger('HumidityChart')
->>>>>>> Stashed changes
 
 #Use a view in CouchDB to get the data
 #use the first key for attribute type
@@ -24,7 +21,7 @@ def getResults(test=False):
     payload={"selector":{"start_date.timestamp":{"$lt":ts}, "status.status_qualifier":"Success", "activity_type":"Environment_Observation", "subject.name":"Air","subject.attribute.name": "Humidity"}, "fields":["start_date.timestamp", "subject.attribute.value"], "sort":[{"start_date.timestamp":"desc"}], "limit":250}        
     db_name = 'mvp_data'
     if test:
-        print payload
+        print(payload)
     server = Server()
     db = server[db_name]
     return db.find(payload)

--- a/MVP/python/Img2Gif.py
+++ b/MVP/python/Img2Gif.py
@@ -22,7 +22,7 @@ def resizeClips(clips, wide):
 
 def getPics(dir, type, start_date, end_date, test=False):
     if test:
-        print "Getting Pics"
+        print("Getting Pics")
     prior_day=0
     pics=[]
     for file in sorted(os.listdir(dir)):
@@ -38,7 +38,7 @@ def getPics(dir, type, start_date, end_date, test=False):
 #            print now, prior_day
                 if now!=prior_day:
                     if test:
-                        print file, os.stat(dir + file).st_size
+                        print(file, os.stat(dir + file).st_size)
                     prior_day = now
                     pics.append(dir+file)
     return pics
@@ -59,14 +59,14 @@ def main(test=False):
     # Frames per second speed
     speed=2
     if test:
-        print "Get Pics from ", dir, " ", start_date, " to ", end_date
+        print("Get Pics from ", dir, " ", start_date, " to ", end_date)
     pics=getPics(dir, type, start_date, end_date, test)
-    print "Get Images"
+    print("Get Images")
 #    imgs=getImages(dir, pics)
     clips=getImageClips(pics, speed)
-    print "Resize Clips"
+    print("Resize Clips")
     clips=resizeClips(clips, size)
-    print "Make Video"
+    print("Make Video")
     makeGIF(clips, png_name)
 
 if __name__=="__main__":

--- a/MVP/python/MVP_Util.py
+++ b/MVP/python/MVP_Util.py
@@ -54,12 +54,12 @@ def UTCStrToLDT(timestamp):
 
 def test():
     utc = datetime.utcnow()
-    print 'UTC', utc
-    print UTCtoLocal(utc)
+    print('UTC', utc)
+    print(UTCtoLocal(utc))
     ts = utc.isoformat()
-    print "Timestamp", ts
-    print UTCStrToLocal(ts)
-    print UTCStrToLDT(ts)
+    print("Timestamp", ts)
+    print(UTCStrToLocal(ts))
+    print(UTCStrToLDT(ts))
 
 
 if __name__=="__main__":

--- a/MVP/python/Server_8000.py
+++ b/MVP/python/Server_8000.py
@@ -3,20 +3,20 @@
 #Date: 7/5/2017
 #NOTE: This needs to be started from the directory where your files to be served are located
 
-#!/usr/bin/python
-import SimpleHTTPServer
-import SocketServer
+#!/usr/bin/python3
+from http.server import SimpleHTTPRequestHandler
+import socketserver
 import mimetypes
 
 PORT = 8000
 
-Handler = SimpleHTTPServer.SimpleHTTPRequestHandler
+Handler = SimpleHTTPRequestHandler
 
 #Handler for SVG
 Handler.extensions_map['.svg']='image/svg+xml'
-httpd = SocketServer.TCPServer(("", PORT), Handler)
+httpd = socketserver.TCPServer(("", PORT), Handler)
 
-print "serving at port", PORT
+print("serving at port", PORT)
 
 #Start the server running
 httpd.serve_forever()

--- a/MVP/python/TempChart.py
+++ b/MVP/python/TempChart.py
@@ -25,7 +25,7 @@ def getResults(test=False):
     payload={"selector":{"start_date.timestamp":{"$lt":ts}, "status.status_qualifier":"Success", "activity_type":"Environment_Observation", "subject.name":"Air","subject.attribute.name": "Temperature"}, "fields":["start_date.timestamp", "subject.attribute.value"], "sort":[{"start_date.timestamp":"desc"}], "limit":250}    
     db_name = 'mvp_data'
     if test:
-        print payload
+        print(payload)
     server = Server()
     db = server[db_name]
     return db.find(payload)

--- a/MVP/python/Thermostat.py
+++ b/MVP/python/Thermostat.py
@@ -32,13 +32,13 @@ def test():
            Raises:
                None
     """
-    print "Test"
+    print("Test")
     adjust_thermostat(40, True)
-    print "Adjust Thermostat 40"
+    print("Adjust Thermostat 40")
     adjust_thermostat(20, True)
-    print "Adjust Thermostat 20"
+    print("Adjust Thermostat 20")
     adjust_thermostat(None, True)
-    print "Adjust Thermostat None"
+    print("Adjust Thermostat None")
 
 if __name__ == "__main__":
     adjust_thermostat()


### PR DESCRIPTION
## Summary
- fix Python 3 `print()` syntax in various modules
- remove merge conflict markers in `HumidityChart.py`
- update outdated `Server_8000.py` imports for Python 3
- ensure environment info pretty print works under Python 3

## Testing
- `python -m py_compile MVP/python/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6849dae2a5c4832fb60c548160910889