### PR TITLE
Fix Light.get_state docstring

### DIFF
--- a/MVP/python/Light.py
+++ b/MVP/python/Light.py
@@ -35,8 +35,7 @@ class Light(object):
             self.logger.debug('Light already OFF - no change')
 
     def get_state(self, test=False):
-        '''Check the GPIO
-    '''
+        '''Check the GPIO'''
         return self.r.get_state(lightPin)
         
 


### PR DESCRIPTION
## Summary
- correct docstring formatting for `get_state` in `Light.py`

## Testing
- `python3 -m py_compile MVP/python/Light.py`

------
https://chatgpt.com/codex/tasks/task_e_6849dcc7781c832facac86de00ca3430