### PR TITLE
Clean up cron file merge markers

### DIFF
--- a/MVP/scripts/MVP_cron.txt
+++ b/MVP/scripts/MVP_cron.txt
@@ -35,11 +35,6 @@ CRON_LOG=/home/pi/MVP/logs/cron.log
 1 6-22 * * * $MVP_SCRIPTS/Webcam.sh >> $CRON_LOG 2>&1
 
 # Render the data for the website
-# 10 * * * * $MVP_SCRIPTS/Render.sh >> $CRON_LOG 2>&1
-<<<<<<< Updated upstream
 */10 * * * * $MVP_SCRIPTS/Render.sh >> $CRON_LOG 2>&1
-=======
-*/15 * * * * $MVP_SCRIPTS/Render.sh >> $CRON_LOG 2>&1
->>>>>>> Stashed changes
 # Check CouchDB heartbeat
 10 * * * * $MVP_SCRIPTS/Heartbeat.sh >> $CRON_LOG 2>&1


### PR DESCRIPTION
## Summary
- remove leftover merge conflict markers from `MVP_cron.txt`
- keep a single 10‑minute cron entry for rendering

## Testing
- `grep -n "Render.sh" MVP/scripts/MVP_cron.txt`


------
https://chatgpt.com/codex/tasks/task_e_6849dcc452d0832fb0b12c0d36bef5e1