### PR TITLE
Fix Fahrenheit spelling

### DIFF
--- a/MVP/python/LogSensors.py
+++ b/MVP/python/LogSensors.py
@@ -15,12 +15,12 @@ def log_sensors(test = False):
         status = 'Success'
         if test:
             status = 'Test'
-        saveList(['Environment_Observation', '', 'Top', 'Air', 'Temperature', "{:10.1f}".format(temp), 'Farenheit', 'SI7021', status, ''])                
+        saveList(['Environment_Observation', '', 'Top', 'Air', 'Temperature', "{:10.1f}".format(temp), 'Fahrenheit', 'SI7021', status, ''])
     except Exception as e:
         status = 'Failure'
         if test:
             status = 'Test'
-        saveList(['Environment_Observation', '', 'Top', 'Air', 'Temperature', '', 'Farenheit', 'SI7021', status, str(e)])                            
+        saveList(['Environment_Observation', '', 'Top', 'Air', 'Temperature', '', 'Fahrenheit', 'SI7021', status, str(e)])
 
     try:
         humid = si.get_humidity()


### PR DESCRIPTION
## Summary
- correct Fahrenheit spelling in `LogSensors.py`

## Testing
- `python3 -m py_compile MVP/python/LogSensors.py`


------
https://chatgpt.com/codex/tasks/task_e_6849dcb3f5c0832f89071a765502a477